### PR TITLE
feat: Allow unknown commit types

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ $ changelog -h
     -x, --exclude <types>  exclude selected commit types (comma separated)
     -f, --file [file]      file to write to, defaults to ./CHANGELOG.md, use - for stdout
     -u, --repo-url [url]   specify the repo URL for commit links, defaults to checking the package.json
+    -a, --allow-unknown    allow unkown commit types
 ```
 
 It's possible to create a `./CHANGELOG.md` file for a specific commit range:

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,4 +17,5 @@ module.exports = CLI
   .option('-t, --tag <range>', 'generate from specific tag or range (e.g. v1.2.3 or v1.2.3..v1.2.4)')
   .option('-x, --exclude <types>', 'exclude selected commit types (comma separated)', list)
   .option('-f, --file [file]', 'file to write to, defaults to ./CHANGELOG.md, use - for stdout', './CHANGELOG.md')
-  .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json');
+  .option('-u, --repo-url [url]', 'specify the repo URL for commit links, defaults to checking the package.json')
+  .option('-a, --allow-unknown', 'allow unkown commit types');

--- a/lib/git.js
+++ b/lib/git.js
@@ -4,7 +4,7 @@ var Bluebird = require('bluebird');
 var CP       = Bluebird.promisifyAll(require('child_process'));
 
 var SEPARATOR      = '===END===';
-var COMMIT_PATTERN = /^(\w*)(?:\(([^)]*?)\)|):(.*?(?:\[([^\]]+?)\]|))\s*$/;
+var COMMIT_PATTERN = /^([^)]*)(?:\(([^)]*?)\)|):(.*?(?:\[([^\]]+?)\]|))\s*$/;
 var FORMAT         = '%H%n%s%n%b%n' + SEPARATOR;
 
 /**

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -76,7 +76,7 @@ exports.markdown = function (version, commits, options) {
   return Bluebird.resolve(commits)
   .bind({ types: {} })
   .each(function (commit) {
-    var type = TYPES[commit.type] ? commit.type : DEFAULT_TYPE;
+    var type = TYPES[commit.type] || options.allowUnknown ? commit.type : DEFAULT_TYPE;
     var category = commit.category;
 
     this.types[type] = this.types[type] || {};
@@ -89,8 +89,13 @@ exports.markdown = function (version, commits, options) {
   })
   .each(function (type) {
     var types = this.types;
+    var typeDescription = TYPES[type];
 
-    content.push('##### ' + TYPES[type]);
+    if (!typeDescription && options.allowUnknown) {
+      typeDescription = TYPES.other + ' (' + type + ')';
+    }
+
+    content.push('##### ' + typeDescription);
     content.push('');
 
     Object.keys(this.types[type]).forEach(function (category) {

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -140,6 +140,26 @@ describe('writer', function () {
       });
     });
 
+    it('does not group uncommon types if unknown types are allowed', function () {
+      var commits = [
+        { type: 'uncommon', category: 'testing', subject: 'did some testing', hash: '1234567890' },
+        { type: 'unknown', category: 'testing', subject: 'did some more testing', hash: '1234567890' }
+      ];
+
+      return Writer.markdown(VERSION, commits, { allowUnknown: true })
+      .then(function (changelog) {
+        return changelog.split('\n');
+      })
+      .filter(function (line) {
+        return line.indexOf('#####') > -1;
+      })
+      .tap(function (lines) {
+        Expect(lines).to.have.length(2);
+        Expect(lines[0]).to.eql('##### Other Changes (uncommon)');
+        Expect(lines[1]).to.eql('##### Other Changes (unknown)');
+      });
+    });
+
     it('keeps a commit category on one line if there is only one commit in it', function () {
       var category = 'testing';
       var subject = 'did some testing';


### PR DESCRIPTION
Taking over from https://github.com/lob/generate-changelog/pull/46.

---

This PR will
* add a flag to allow unknown commit types.

### Reason
Sometimes you want to use other commit types in your repository (e.g. `run-fix` to mark fixes concerning only the current feature run). These should not all be grouped into "Other changes" then.

### Result
Commits with unknown types will then be each grouped into `Other changes (<commit type>)`.

### Example

##### New Features
* **docs:**  Add docs (fd616edf)

##### Other Changes (run-fix)

*  **docs**: Fixed typo (658297e9)